### PR TITLE
add shebang; delete version comment because it won't trigger otherwise

### DIFF
--- a/hack_check.py
+++ b/hack_check.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import subprocess
 import time
 import platform
@@ -5,10 +7,9 @@ import json
 
 # "We are checking for malicious libraries that may have been inserted onto your computer
 #  through a PyPi mislabeling technique"
-# "Note, this program was written to support python version 2.7.x"
 
 # Extra context for you as you.
-print "python verison: " + platform.python_version()
+print "python version: " + platform.python_version()
 print "pip version: " + subprocess.check_output(['pip', '--version'])
 
 # Visual interface because.


### PR DESCRIPTION
Adding a shebang to make it immediately clear that the script is for py2.7. Just realizing now that my commit says the comment line won't trigger; duh. Not editing that out to preserve my goof (I must have been thinking about the print statements that follow) That said, the shebang is more concise.